### PR TITLE
chore: fix missing includes of cstdint

### DIFF
--- a/src/io-util.hh
+++ b/src/io-util.hh
@@ -6,6 +6,7 @@
 #include <vector>
 #include <algorithm>
 #include <map>
+#include <cstdint>
 
 #ifdef TINYUSDZ_ANDROID_LOAD_FROM_ASSETS
 #include <android/asset_manager.h>

--- a/src/str-util.hh
+++ b/src/str-util.hh
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <set>
+#include <cstdint>
 
 namespace tinyusdz {
 

--- a/src/tydra/facial.cc
+++ b/src/tydra/facial.cc
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <string>
+#include <cstdint>
 
 //
 #include "facial.hh"


### PR DESCRIPTION
Thank you for this awesome library!

I had a small problem when compiling using clang. This fixes compilation of this library using clang++-18 on Ubuntu 23.10 where it was missing a few includes of `<cstdint>`.

Please let me know whether you prefer `<cstdint>` or the deprecated `<stdint.h>`. At least in one of the cases `<cstdint>` has to be used to provide `std::unt32_t` definitions. `<cstdint>` does not define `::uint32_t` as defined by the C++, only `std::uint32_t` but in practice it also defines`::uint32_t` for all implementation that I'm aware of. 