### PR TITLE
Fix bug: continue processing model if skeleton check fails

### DIFF
--- a/src/tydra/render-data.cc
+++ b/src/tydra/render-data.cc
@@ -3703,31 +3703,30 @@ bool RenderSceneConverter::ConvertMesh(
 
       if (skelPath.is_valid()) {
         SkelHierarchy skel;
-        nonstd::optional<Animation> anim;
-        if (!ConvertSkeletonImpl(env, mesh, &skel, &anim)) {
-          return false;
+        nonstd::optional <Animation> anim;
+        if (ConvertSkeletonImpl(env, mesh, &skel, &anim)) {
+          DCOUT("Converted skeleton attached to : " << abs_path);
+
+          auto it = std::find_if(skeletons.begin(), skeletons.end(), [&abs_path](const SkelHierarchy &sk) {
+                                     return sk.abs_path == abs_path.full_path_name();
+                                 });
+
+          if (anim) {
+              skel.anim_id = int(animations.size());
+              animations.emplace_back(anim.value());
+          }
+
+          int skel_id{0};
+          if (it != skeletons.end()) {
+              skel_id = int(std::distance(skeletons.begin(), it));
+          } else {
+              skel_id = int(skeletons.size());
+              skeletons.emplace_back(std::move(skel));
+          }
+
+          dst.skel_id = skel_id;
+
         }
-        DCOUT("Converted skeleton attached to : " << abs_path);
-
-        auto it = std::find_if(skeletons.begin(), skeletons.end(), [&abs_path](const SkelHierarchy &sk) {
-          return sk.abs_path == abs_path.full_path_name();
-        });
-
-        if (anim) {
-          skel.anim_id = int(animations.size());
-          animations.emplace_back(anim.value());
-        }
-
-        int skel_id{0};
-        if (it != skeletons.end()) {
-          skel_id = int(std::distance(skeletons.begin(), it));
-        } else {
-          skel_id = int(skeletons.size());
-          skeletons.emplace_back(std::move(skel));
-        }
-
-        dst.skel_id = skel_id;
-
       }
     }
 


### PR DESCRIPTION
There's a problem in [`src/tydra/render-data.cc`](https://github.com/lighttransport/tinyusdz/blob/dev/src/tydra/render-data.cc) around line `3704`.  If the skeleton check fails, the model processing is aborted at that point, instead of continuing with other crucial model processing steps...
```
  if (skelPath.is_valid()) {
    SkelHierarchy skel;
    nonstd::optional<Animation> anim;
    if (!ConvertSkeletonImpl(env, mesh, &skel, &anim)) {
      return false; // << Early abort doesn't continue processing model
    }
    // Process skeleton
  }
  // Additional model processing from here never happens if skeleton check fails
  //
  // 6. BlendShapes
  //
...
  //
  // 7. Compute normals
  //
...
  //
  // 8. Build indices
  //
```

If the logic is inverted and early (aborting) return removed, the model processing is allowed to continue even if the skeleton check fails
```
  if (skelPath.is_valid()) {
    SkelHierarchy skel;
    nonstd::optional<Animation> anim;
    if (ConvertSkeletonImpl(env, mesh, &skel, &anim)) {
      // Process skeleton
    }
  ...
  }
  // Additional model processing happens here regardless of status of skeleton check
  //
  // 6. BlendShapes
  //
...
  //
  // 7. Compute normals
  //
...
  //
  // 8. Build indices
  //
```

Additional details in #176 