### PR TITLE
perf: reserve memory for prim children

### DIFF
--- a/src/usdc-reader.cc
+++ b/src/usdc-reader.cc
@@ -3293,6 +3293,7 @@ bool USDCReader::Impl::ReconstructPrimRecursively(
   {
     const crate::CrateReader::Node &node = _nodes[size_t(current)];
     DCOUT("node.Children.size = " << node.GetChildren().size());
+    currPrimPtr->children().reserve(node.GetChildren().size());
     for (size_t i = 0; i < node.GetChildren().size(); i++) {
       DCOUT("Reconstuct Prim children: " << i << " / "
                                          << node.GetChildren().size());

--- a/src/usdc-reader.cc
+++ b/src/usdc-reader.cc
@@ -3293,7 +3293,9 @@ bool USDCReader::Impl::ReconstructPrimRecursively(
   {
     const crate::CrateReader::Node &node = _nodes[size_t(current)];
     DCOUT("node.Children.size = " << node.GetChildren().size());
-    currPrimPtr->children().reserve(node.GetChildren().size());
+    if (currPrimPtr) {
+        currPrimPtr->children().reserve(node.GetChildren().size());
+    }
     for (size_t i = 0; i < node.GetChildren().size(); i++) {
       DCOUT("Reconstuct Prim children: " << i << " / "
                                          << node.GetChildren().size());


### PR DESCRIPTION
Optimize the performance of constructing prims, avoiding too frequent reallocation of the children vector.




