### PR TITLE
Fixed caching in Stage::find_prim_by_prim_id, enforce boolean as return values

### DIFF
--- a/src/asset-resolution.hh
+++ b/src/asset-resolution.hh
@@ -228,7 +228,7 @@ class AssetResolutionResolver {
   }
 
   bool has_asset_resolution_handler(const std::string &ext_name) {
-    return _asset_resolution_handlers.count(ext_name);
+    return _asset_resolution_handlers.count(ext_name) > 0;
   }
 
 

--- a/src/prim-types.hh
+++ b/src/prim-types.hh
@@ -86,7 +86,7 @@ class ordered_dict {
   }
 
   bool count(const std::string &key) const {
-    return _m.count(key);
+    return _m.count(key) > 0;
   }
 
   void insert(const std::string &key, const T &value) {
@@ -2635,11 +2635,11 @@ class Attribute {
       return false;
     }
 
-    return _paths.size();
+    return _paths.size() > 0;
   }
 
   bool has_connections() const {
-    return _paths.size();
+    return _paths.size() > 0;
   }
 
 
@@ -3177,7 +3177,7 @@ class MaterialBinding {
     } else if (mat_purpose.str() == "preview") {
       return has_materialBindingPreview();
     } else {
-      return _materialBindingMap.count(mat_purpose.str());
+      return _materialBindingMap.count(mat_purpose.str()) > 0;
     }
   }
 
@@ -3257,7 +3257,7 @@ class MaterialBinding {
       return false;
     }
 
-    return _materialBindingCollectionMap.count(tok);
+    return _materialBindingCollectionMap.count(tok) > 0;
   }
 
   void set_materialBindingCollection(const value::token &tok, const value::token &mat_purpose, const Relationship &rel) {
@@ -4244,7 +4244,7 @@ class Layer {
 
   // Check if `primname` exists in root Prims?
   bool has_primspec(const std::string &primname) const {
-    return _prim_specs.count(primname);
+    return _prim_specs.count(primname) > 0;
   }
 
   ///

--- a/src/primvar.hh
+++ b/src/primvar.hh
@@ -55,7 +55,7 @@ struct PrimVar {
   }
 
   bool has_timesamples() const {
-    return _ts.size();
+    return _ts.size() > 0;
   }
 
   bool is_scalar() const {

--- a/src/stage.cc
+++ b/src/stage.cc
@@ -230,7 +230,8 @@ bool Stage::find_prim_by_prim_id(const uint64_t prim_id, const Prim *&prim,
     auto ret = _prim_id_cache.find(prim_id);
     if (ret != _prim_id_cache.end()) {
       DCOUT("Found cache.");
-      return ret->second;
+      prim = ret->second;
+      return true;
     }
   }
 

--- a/src/usdGeom.hh
+++ b/src/usdGeom.hh
@@ -197,7 +197,7 @@ class GeomPrimvar {
   }
 
   bool has_default_indices() const { return !_indices.empty(); }
-  bool has_timesampled_indices() const { return _ts_indices.size(); }
+  bool has_timesampled_indices() const { return _ts_indices.size() > 0; }
 
   bool has_indices() const {
     return has_default_indices() || has_timesampled_indices();


### PR DESCRIPTION
Hi, this pull request fixes a bug in the caching usage of Stage::find_prim_by_prim_id and enforces boolean return values for a bunch of functions where integers are returned