### PR TITLE
Keep base properties when applying references in composition

### DIFF
--- a/src/composition.cc
+++ b/src/composition.cc
@@ -1289,6 +1289,10 @@ static bool InheritPrimSpecImpl(PrimSpec &dst, const PrimSpec &src,
       // replace
       ps.props().at(prop.first) = prop.second;
     }
+    else {
+      // re-add
+      ps.props()[prop.first] = prop.second;
+    }
   }
 
   // Overide child primspecs.


### PR DESCRIPTION
While attempting to load the KitchenSet with the Unreal Engine plugin i am working on, i noticed that the references resolving system swallows the base properties.

Example:

```
def "Refridgerator_1"
                (
                    prepend references = @./assets/Refridgerator/Refridgerator.usd@
                )
                {
                    string HelloWorld = "Hello World"
                    double3 xformOp:translate = (259.9341506958008, 95.84612274169922, -0.5277154445648193)
                    uniform token[] xformOpOrder = ["xformOp:translate"]
                }
```

By flattening/applying the reference you get:

```
def Xform "Refridgerator_1"
                (
                    kind = "component"
                    assetInfo = {
                        asset identifier = @assets/Refridgerator/Refridgerator.usd@
                        string name = "Refridgerator"
                    }
                    payload = @./Refridgerator_payload.usd@</Refridgerator>
                    variants = {
                        string modelingVariant = "Decorated"
                    }
                    prepend variantSets = ["modelingVariant"]
                )
                {
              
                }
```

without the original properties (i have added the HelloWorld one to keep track).

This patch addresses it by re-adding the properties that are not found in the applied reference.

Once applied i was able to correctly get the KitchenSet transforms:

![image](https://github.com/user-attachments/assets/86bca26b-4716-4999-8bb8-0c1e66028dfb)


