### PR TITLE
Implemented ReadDoubleVector instead of ReadDoubleArray for crate::CrateDataTypeId::CRATE_DATA_TYPE_DOUBLE_VECTOR

### DIFF
--- a/src/crate-reader.hh
+++ b/src/crate-reader.hh
@@ -340,6 +340,8 @@ class CrateReader {
   bool ReadFloatArray(bool is_compressed, std::vector<float> *d);
   bool ReadDoubleArray(bool is_compressed, std::vector<double> *d);
 
+  bool ReadDoubleVector(std::vector<double> *d);
+
   // template <class T>
   // struct IsIntType {
   //   static const bool value =


### PR DESCRIPTION
This patch addresses the management of the DoubleVector type in crates:

the original approach was to use ReadDoubleArray for crate::CrateDataTypeId::CRATE_DATA_TYPE_DOUBLE_VECTOR but the OpenUSD implementation has a dedicated codepath for it (that does not account for compression or 32bit sizes of older formats)

https://github.com/PixarAnimationStudios/OpenUSD/blob/release/pxr/usd/usd/crateFile.cpp#L1069

```cpp
 template <class T>
    vector<T> _Read(vector<T> *) {
        auto sz = Read<uint64_t>();
        vector<T> vec(sz);
        ReadContiguous(vec.data(), sz);
        return vec;
    }
``` 

This patch adds a ReadDoubleVector that does the same thing as the code above.

In addition to this the patch adds a check for zero-sized array in ReadDoubleArray 

This patch allows to load the spinning top asset from OpenUSD and flatten it with all of the TimeSamples (https://github.com/PixarAnimationStudios/OpenUSD/blob/release/extras/usd/tutorials/animatedTop/top.geom.usd)

Note that the top.geom.usd asset has TimeSampled indices, that will be supported in a different pull request i am going to send in few minutes