### PR TITLE
Added time support for face indices

### DIFF
--- a/src/usdGeom.cc
+++ b/src/usdGeom.cc
@@ -811,7 +811,7 @@ Interpolation GeomMesh::get_normalsInterpolation() const {
   return Interpolation::Vertex;  // default 'vertex'
 }
 
-const std::vector<int32_t> GeomMesh::get_faceVertexCounts() const {
+const std::vector<int32_t> GeomMesh::get_faceVertexCounts(double time) const {
   std::vector<int32_t> dst;
 
   if (!faceVertexCounts.authored() || faceVertexCounts.is_blocked()) {
@@ -825,15 +825,14 @@ const std::vector<int32_t> GeomMesh::get_faceVertexCounts() const {
 
   if (auto pv = faceVertexCounts.get_value()) {
     std::vector<int32_t> val;
-    // TOOD: timesamples
-    if (pv.value().get_scalar(&val)) {
+    if (pv.value().get(time, &val, value::TimeSampleInterpolationType::Held)) {
       dst = std::move(val);
     }
   }
   return dst;
 }
 
-const std::vector<int32_t> GeomMesh::get_faceVertexIndices() const {
+const std::vector<int32_t> GeomMesh::get_faceVertexIndices(double time) const {
   std::vector<int32_t> dst;
 
   if (!faceVertexIndices.authored() || faceVertexIndices.is_blocked()) {
@@ -847,8 +846,7 @@ const std::vector<int32_t> GeomMesh::get_faceVertexIndices() const {
 
   if (auto pv = faceVertexIndices.get_value()) {
     std::vector<int32_t> val;
-    // TOOD: timesamples
-    if (pv.value().get_scalar(&val)) {
+    if (pv.value().get(time, &val, value::TimeSampleInterpolationType::Held)) {
       dst = std::move(val);
     }
   }

--- a/src/usdGeom.hh
+++ b/src/usdGeom.hh
@@ -797,14 +797,14 @@ struct GeomMesh : GPrim {
   ///
   /// @return face vertex counts vector(copied)
   ///
-  const std::vector<int32_t> get_faceVertexCounts() const;
+  const std::vector<int32_t> get_faceVertexCounts(double time = value::TimeCode::Default()) const;
 
   ///
   /// @brief Returns `faceVertexIndices`.
   ///
   /// @return face vertex indices vector(copied)
   ///
-  const std::vector<int32_t> get_faceVertexIndices() const;
+  const std::vector<int32_t> get_faceVertexIndices(double time = value::TimeCode::Default()) const;
 
   //
   // SubD attribs.


### PR DESCRIPTION
This tiny patch adds support for TimeSampled faceIndices, required for loading the OpenUSD top.geom.usd asset (https://github.com/PixarAnimationStudios/OpenUSD/blob/release/extras/usd/tutorials/animatedTop/top.geom.usd).

To fully load the assets this other patch is required: https://github.com/lighttransport/tinyusdz/pull/197

The interpolation is hardcoded as Held as there is no point in other forms of usage.