### PR TITLE
added GPrim::get_displayColors and GPrim::get_displayColorsInterpolation

### DIFF
--- a/src/usdGeom.cc
+++ b/src/usdGeom.cc
@@ -796,6 +796,23 @@ const std::vector<value::normal3f> GeomMesh::get_normals(
   return dst;
 }
 
+const std::vector<value::color3f> GPrim::get_displayColors(
+    double time, value::TimeSampleInterpolationType interp) const {
+  std::vector<value::color3f> dst;
+
+  std::string err;
+  if (has_primvar("displayColor")) {
+    GeomPrimvar primvar;
+    if (!get_primvar("displayColor", &primvar, &err)) {
+      return dst;
+    }
+
+    primvar.flatten_with_indices(time, &dst, interp);
+  }
+
+  return dst;
+}
+
 Interpolation GeomMesh::get_normalsInterpolation() const {
   if (props.count("primvars:normals")) {
     const auto &prop = props.at("primvars:normals");
@@ -806,6 +823,19 @@ Interpolation GeomMesh::get_normalsInterpolation() const {
     }
   } else if (normals.metas().interpolation) {
     return normals.metas().interpolation.value();
+  }
+
+  return Interpolation::Vertex;  // default 'vertex'
+}
+
+Interpolation GPrim::get_displayColorsInterpolation() const {
+  if (props.count("primvars:displayColor")) {
+    const auto &prop = props.at("primvars:displayColor");
+    if (prop.get_attribute().type_name() == "color3f[]") {
+      if (prop.get_attribute().metas().interpolation) {
+        return prop.get_attribute().metas().interpolation.value();
+      }
+    }
   }
 
   return Interpolation::Vertex;  // default 'vertex'

--- a/src/usdGeom.hh
+++ b/src/usdGeom.hh
@@ -363,6 +363,13 @@ struct GPrim : Xformable, MaterialBinding, Collection {
 
   bool get_displayOpacity(float *opacity, const double t = value::TimeCode::Default(), const value::TimeSampleInterpolationType tinterp = value::TimeSampleInterpolationType::Linear) const;
 
+  const std::vector<value::color3f> get_displayColors(
+      double time = value::TimeCode::Default(),
+      value::TimeSampleInterpolationType interp =
+          value::TimeSampleInterpolationType::Linear) const;
+
+  Interpolation get_displayColorsInterpolation() const;
+
   RelationshipProperty proxyPrim;
 
 #if 0


### PR DESCRIPTION
This patch adds two handy functions for getting the displayColors as array:

```cpp
const std::vector<value::color3f> get_displayColors(
      double time = value::TimeCode::Default(),
      value::TimeSampleInterpolationType interp =
          value::TimeSampleInterpolationType::Linear) const;

  Interpolation get_displayColorsInterpolation() const;
```

This is mostly useful for animated colors