### PR TITLE
Fixed typeName management in override

### DIFF
--- a/src/composition.cc
+++ b/src/composition.cc
@@ -1221,6 +1221,11 @@ static bool OverridePrimSpecRec(uint32_t depth, PrimSpec &dst,
   if (depth > (1024 * 1024 * 128)) {
     PUSH_ERROR_AND_RETURN("PrimSpec tree too deep.");
   }
+  
+  // overrides can omit types (in such a case get it from the src)
+  if (dst.typeName().empty()) {
+      dst.typeName() = src.typeName();
+  }
 
   DCOUT("update_from");
   DCOUT(print_prim_metas(src.metas(), 1));


### PR DESCRIPTION
Assuming two layers with the first one refering the second:

base.usda
```
#usda 1.0

def Scope "Root"
{
    def Scope "SubRoot"
    (
        prepend references = @hello.usda@
    )
    {
        def Mesh "HelloWorld"
        {
            
        }
    }
}
```
hello.usda

```
#usda 1.0
(
    defaultPrim = "Main"
)

def "Main"
{
    def "HelloWorld"
    {
        string value = "Hello World"
    }
}
```

The flattened result should be (output from usdcat):

```
#usda 1.0
(
)

def Scope "Root"
{
    def Scope "SubRoot"
    {
        def Mesh "HelloWorld"
        {
            string value = "Hello World"
        }
    }
}
```

While tusdcat returns

```
#usda 1.0

def Scope "Root"
{
    def Scope "SubRoot"
    {
        def "HelloWorld"
        {
            string value = "Hello World"
        }
    }
}
```

The reason is that the code assumes typeName to always be available while USD allows it to be omitted (like in the example).

The patch honours the original typeName if none is specified in the referenced asset
