### PR TITLE
Fixed Inheritance caching bug and typeName management

### DIFF
--- a/src/composition.cc
+++ b/src/composition.cc
@@ -1275,9 +1275,11 @@ static bool InheritPrimSpecImpl(PrimSpec &dst, const PrimSpec &src,
   // Then override it with `dst`
   PrimSpec ps = src;  // copy
 
-  // Keep PrimSpec name, typeName and spec from `dst`
+  // Keep PrimSpec name, typeName (if not empty) and spec from `dst`
   ps.name() = dst.name();
-  ps.typeName() = dst.typeName();
+  if (!dst.typeName().empty()) {
+    ps.typeName() = dst.typeName();
+  }
   ps.specifier() = dst.specifier();
 
   // Override metadataum

--- a/src/prim-types.cc
+++ b/src/prim-types.cc
@@ -2175,7 +2175,8 @@ bool Layer::find_primspec_at(const Path &path, const PrimSpec **ps,
     auto ret = _primspec_path_cache.find(path.prim_part());
     if (ret != _primspec_path_cache.end()) {
       DCOUT("Found cache.");
-      return ret->second;
+      (*ps) = ret->second;
+      return true;
     }
   }
 


### PR DESCRIPTION
This patch addresses the minor Inheritance composition arc issues reported here: https://github.com/lighttransport/tinyusdz/issues/209

In addition to honouring the empty typeName of the destination it fixes a buf in the caching management logic.

Note that the issue covers a third aspect: disallowing inheritance from paths under the inheriting one. I am not sure it is a check to implement, so eventually i will update the pull request 