### PR TITLE
Npm publish

### DIFF
--- a/.github/workflows/wasmPublish.yml
+++ b/.github/workflows/wasmPublish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Prepare npm
         working-directory: ${{ github.workspace }}/web/npm
         run: |
-          cp ../web/main.js .
+          cp ../dist/* .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wasmPublish.yml
+++ b/.github/workflows/wasmPublish.yml
@@ -2,9 +2,23 @@
 name: Build and publish wasm
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["dev"]
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'NPM Release Version'
+        required: true 
+        type: string
+        default: 1.0.0
+      NPM_tag:
+        description: 'NPM Tag'
+        required: true
+        type: string
+        default: preview
+      NPM_publish_arg:
+        description: 'NPM Publish arg'
+        required: false
+        type: string
+        default: --dry-run
 
 jobs:
   tinyusdz-wasm:
@@ -47,6 +61,11 @@ jobs:
         with:
           name: 'tinyusdz'
           path: ${{ github.workspace }}/web/npm
-          
-      - name: Deploy to NPM
-        uses: actions/deploy-pages@v4
+
+      - name: Version & Publish Package
+        run: |
+          npm version --no-git-tag-version ${{ github.event.inputs.release_version }}
+          npm publish --access public --tag ${{ github.event.inputs.NPM_tag }} ${{ github.event.inputs.NPM_publish_arg }}
+        working-directory: ${{ github.workspace }}/web/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/wasmPublish.yml
+++ b/.github/workflows/wasmPublish.yml
@@ -1,0 +1,51 @@
+# Simple workflow that builds wasm and publish to npm registry
+name: Build and publish wasm
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["dev"]
+
+jobs:
+  tinyusdz-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - name: Setup Emscripten SDK
+        run: |
+          git clone https://github.com/emscripten-core/emsdk.git
+          cd emsdk
+          # from https://github.com/Twinklebear/webgpu-cpp-usdz/blob/main/.github/workflows/deploy-page.yml
+          # TODO: 3.1.52 has a change to WebGPU API that is incompatible
+          # with the C++ bindings I have in the repo?
+          ./emsdk install 3.1.51
+          ./emsdk activate 3.1.51
+      - name: Configure
+        run: |
+          source ./emsdk/emsdk_env.sh
+          cd web
+          mkdir cmake-build
+          cd cmake-build
+          emcmake cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel
+      - name: Build WASM
+        working-directory: ${{ github.workspace }}/web/cmake-build
+        run: |
+          source ../../emsdk/emsdk_env.sh
+          make
+
+      - name: Prepare npm
+        working-directory: ${{ github.workspace }}/web/npm
+        run: |
+          cp ../web/main.js .
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          # Upload web/npm folder
+          path: ${{ github.workspace }}/web/npm
+      - name: Deploy to NPM
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/wasmPublish.yml
+++ b/.github/workflows/wasmPublish.yml
@@ -43,9 +43,10 @@ jobs:
           cp ../web/main.js .
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
-          # Upload web/npm folder
+          name: 'tinyusdz'
           path: ${{ github.workspace }}/web/npm
+          
       - name: Deploy to NPM
         uses: actions/deploy-pages@v4

--- a/web/npm/package.json
+++ b/web/npm/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "tinyusdz",
+  "version": "0.0.1",
+  "description": "Tinyusdz wasm",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "usdz"
+  ],
+  "author": "",
+  "license": "ISC"
+}

--- a/web/npm/package.json
+++ b/web/npm/package.json
@@ -2,7 +2,7 @@
   "name": "tinyusdz",
   "version": "0.0.1",
   "description": "Tinyusdz wasm",
-  "main": "index.js",
+  "main": "tinyusdz.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/web/npm/readme.md
+++ b/web/npm/readme.md
@@ -1,0 +1,1 @@
+# Tinyusdz


### PR DESCRIPTION
New manual GitHub actions workflow that builds and publish an NPM package.
My indend is then to use unpkg tp expose tinyusdz and do usdz loading in Babylon.js https://github.com/BabylonJS/Babylon.js/pull/16005

tinyusdz NPM should be own (and created) by its maintainer (IMHO).