### PR TITLE
Explicit joint orders

### DIFF
--- a/models/explicit-joint-orders-001.usda
+++ b/models/explicit-joint-orders-001.usda
@@ -1,0 +1,13 @@
+#usda 1.0
+
+def Mesh "Arm" {
+  uniform token[] skel:joints = ["Shoulder/Elbow", "Shoulder"]
+  int[] primvars:skel:jointIndices = [1,1,1,1, 1,1,1,1, 0,0,0,0] (
+    interpolation = "vertex"
+    elementSize = 1
+  )
+  float[] primvars:skel:jointWeights = [1,1,1,1, 1,1,1,1, 1,1,1,1] (
+    interpolation = "vertex"
+    elementSize = 1
+  )
+}

--- a/src/prim-reconstruct.cc
+++ b/src/prim-reconstruct.cc
@@ -54,6 +54,8 @@ constexpr auto kMaterialBinding = "material:binding";
 constexpr auto kMaterialBindingCollection = "material:binding:collection";
 constexpr auto kMaterialBindingPreview = "material:binding:preview";
 constexpr auto kSkelSkeleton = "skel:skeleton";
+// Explit Joint Order
+constexpr auto kSkelJoints = "skel:joints";
 constexpr auto kSkelAnimationSource = "skel:animationSource";
 constexpr auto kSkelBlendShapes = "skel:blendShapes";
 constexpr auto kSkelBlendShapeTargets = "skel:blendShapeTargets";
@@ -3738,6 +3740,8 @@ bool ReconstructPrim<GeomMesh>(
 
       }
     }
+
+    PARSE_TYPED_ATTRIBUTE(table, prop, kSkelJoints, GeomMesh, mesh->joints)
 
     // generic
     ADD_PROPERTY(table, prop, GeomMesh, mesh->props)

--- a/src/prim-reconstruct.cc
+++ b/src/prim-reconstruct.cc
@@ -54,8 +54,6 @@ constexpr auto kMaterialBinding = "material:binding";
 constexpr auto kMaterialBindingCollection = "material:binding:collection";
 constexpr auto kMaterialBindingPreview = "material:binding:preview";
 constexpr auto kSkelSkeleton = "skel:skeleton";
-// Explit Joint Order
-constexpr auto kSkelJoints = "skel:joints";
 constexpr auto kSkelAnimationSource = "skel:animationSource";
 constexpr auto kSkelBlendShapes = "skel:blendShapes";
 constexpr auto kSkelBlendShapeTargets = "skel:blendShapeTargets";
@@ -3740,8 +3738,6 @@ bool ReconstructPrim<GeomMesh>(
 
       }
     }
-
-    PARSE_TYPED_ATTRIBUTE(table, prop, kSkelJoints, GeomMesh, mesh->joints)
 
     // generic
     ADD_PROPERTY(table, prop, GeomMesh, mesh->props)

--- a/src/tydra/render-data.cc
+++ b/src/tydra/render-data.cc
@@ -3704,6 +3704,7 @@ bool RenderSceneConverter::ConvertMesh(
       if (skelPath.is_valid()) {
         SkelHierarchy skel;
         nonstd::optional<Animation> anim;
+        // TODO: cache skeleton conversion
         if (!ConvertSkeletonImpl(env, mesh, &skel, &anim)) {
           return false;
         }
@@ -3736,6 +3737,7 @@ bool RenderSceneConverter::ConvertMesh(
         } else {
           skel_id = int(skeletons.size());
           skeletons.emplace_back(std::move(skel));
+          DCOUT("add skeleton\n");
         }
 
         dst.skel_id = skel_id;

--- a/src/tydra/render-data.cc
+++ b/src/tydra/render-data.cc
@@ -15,7 +15,7 @@
 //   - [x] Support SkelAnimation
 //     - [x] joint animation
 //     - [x] blendshape animation
-//     - [ ] explicit joint order
+//     - [x] explicit joint order
 //   - [ ] Support Inbetween BlendShape
 //   - [ ] Support material binding collection(Collection API)
 //   - [ ] Support multiple skel animation
@@ -3750,9 +3750,9 @@ bool RenderSceneConverter::ConvertMesh(
     // If the mesh has `skel:joints`, remap jointIndex.
     {
       std::vector<value::token> joints = mesh.get_joints();
-      if ((dst.skel_id >= 0) && joints.size()) {
-        DCOUT("has explicit joint orders.\n");
-      }
+      //if ((dst.skel_id >= 0) && joints.size()) {
+      //  DCOUT("has explicit joint orders.\n");
+      //}
 
       const auto &skel = skeletons[size_t(dst.skel_id)];
 
@@ -3770,7 +3770,7 @@ bool RenderSceneConverter::ConvertMesh(
         int dst_idx = name_to_index_map.at(joint_name);
         index_remap[int(i)] = dst_idx;
 
-        DCOUT("remap " << i << " to " << dst_idx);
+        //DCOUT("remap " << i << " to " << dst_idx);
       }
 
       for (size_t i = 0; i < dst.joint_and_weights.jointIndices.size(); i++) {
@@ -3779,7 +3779,7 @@ bool RenderSceneConverter::ConvertMesh(
           int dst_idx = index_remap[src_idx];
 
           dst.joint_and_weights.jointIndices[i] = dst_idx;
-      
+          //DCOUT("jointIndex modified: remap " << src_idx << " to " << dst_idx);
         }
       }
 

--- a/src/tydra/scene-access.cc
+++ b/src/tydra/scene-access.cc
@@ -3076,5 +3076,30 @@ bool BuildSkelHierarchy(const Skeleton &skel, SkelNode &dst, std::string *err) {
   return true;
 }
 
+namespace {
+
+void BuildSkelNameToIndexMapRec(const SkelNode &node, std::map<std::string, int> &m) {
+
+  if (node.joint_name.size() && (node.joint_id >= 0)) {
+    m[node.joint_name] = node.joint_id;
+  }
+
+  for (const auto &child : node.children) {
+    BuildSkelNameToIndexMapRec(child, m);
+  }
+
+}
+
+} // namespace
+
+std::map<std::string, int> BuildSkelNameToIndexMap(const SkelHierarchy &skel) {
+
+  std::map<std::string, int> m;
+
+  BuildSkelNameToIndexMapRec(skel.root_node, m);
+  
+  return m;
+}
+
 }  // namespace tydra
 }  // namespace tinyusdz

--- a/src/tydra/scene-access.hh
+++ b/src/tydra/scene-access.hh
@@ -546,6 +546,8 @@ class SkelHierarchy {
 
 };
 
+std::map<std::string, int> BuildSkelNameToIndexMap(const SkelHierarchy &skel);
+
 ///
 /// Extract skeleleton info from Skeleton and build skeleton(bone) hierarchy.
 ///

--- a/src/usdGeom.cc
+++ b/src/usdGeom.cc
@@ -883,12 +883,56 @@ const std::vector<int32_t> GeomMesh::get_faceVertexIndices(double time) const {
   return dst;
 }
 
-const std::vector<value::token> GeomMesh::get_joints() const {
-  if (props.count("primvars:skel:joint")) {
+std::vector<value::token> GeomMesh::get_joints() const {
+  constexpr auto kSkelJoints = "skel:joints";
+#if 0
+  if (has_primvar(kSkelJoints)) {
+    // 'primvars:skel:joints'
+    std::string err;
+    GeomPrimvar primvar;
+    if (!get_primvar(kSkelJoints, &primvar, &err)) {
+      DCOUT("Invalid `skel:joints` primvar. err = " << err);
+      return {};
+    }
 
+    if (primvar.has_indices()) {
+      // indexed primvar for skel:joint is not supported 
+      DCOUT("Indexed primvar is not supported for `skel:joints`");
+      return {};
+    }
+
+    const Attribute &attr = primvar.get_attribute();
+    if (!attr.is_uniform()) {
+      DCOUT("`skel:joints` must be uniform attribute");
+      return {};
+    }
+
+    std::vector<value::token> dst;
+    if (!primvar.get_value(&dst)) {
+      DCOUT("`skel:joints` must be token[] type, but got " << primvar.type_name());
+    }
   } else {
-    return joints;
+#endif
+  {
+    // lookup `skel:joints` prop
+    if (!props.count(kSkelJoints)) {
+      return {};
+    }
+
+    const auto &prop = props.at(kSkelJoints);
+    if (prop.get_attribute().is_uniform() && prop.get_attribute().type_name() == "token[]") {
+      
+      std::vector<value::token> dst;
+      if (!prop.get_attribute().get_value(&dst)) {
+        return {};
+      }
+
+      return dst;
+      
+    } 
+    DCOUT("`skel:joints` must be uniform token[] attribute, but got " << prop.value_type_name() << " (or Relationship))");
   }
+  return {};
 }
 
 // static

--- a/src/usdGeom.cc
+++ b/src/usdGeom.cc
@@ -883,6 +883,14 @@ const std::vector<int32_t> GeomMesh::get_faceVertexIndices(double time) const {
   return dst;
 }
 
+const std::vector<value::token> GeomMesh::get_joints() const {
+  if (props.count("primvars:skel:joint")) {
+
+  } else {
+    return joints;
+  }
+}
+
 // static
 bool GeomSubset::ValidateSubsets(
     const std::vector<const GeomSubset *> &subsets,

--- a/src/usdGeom.hh
+++ b/src/usdGeom.hh
@@ -903,8 +903,7 @@ struct GeomMesh : GPrim {
 
 #endif
 
-  // Get Explicit Joint orders: uniform token[] type.
-  //  `skel:joints` or `primvars:skel:joints`
+  // Get Explicit Joint orders: `uniform token[] skel:joints`
   std::vector<value::token> get_joints() const;
 
 #if 0 // Deprecated: Use tydra::GetGeomSubsets() instead.

--- a/src/usdGeom.hh
+++ b/src/usdGeom.hh
@@ -756,6 +756,9 @@ struct GeomMesh : GPrim {
   // Make SkelBindingAPI first citizen.
   nonstd::optional<Relationship> skeleton;  // rel skel:skeleton
 
+  // For Explicit Joint Orders
+  TypedAttribute<std::vector<value::token>> joints; // uniform token[] skel:joints
+
   //
   // Utility functions
   //
@@ -902,6 +905,9 @@ struct GeomMesh : GPrim {
   std::vector<GeomSubset> geom_subset_children;
 
 #endif
+
+  // Get Explicit Joint orders:  skel:joints or primvars:skel:joints
+  bool get_joints(std::vector<value::token> *joints) const;
 
 #if 0 // Deprecated: Use tydra::GetGeomSubsets() instead.
   ///

--- a/src/usdGeom.hh
+++ b/src/usdGeom.hh
@@ -756,9 +756,6 @@ struct GeomMesh : GPrim {
   // Make SkelBindingAPI first citizen.
   nonstd::optional<Relationship> skeleton;  // rel skel:skeleton
 
-  // For Explicit Joint Orders
-  TypedAttribute<std::vector<value::token>> joints; // uniform token[] skel:joints
-
   //
   // Utility functions
   //
@@ -906,8 +903,9 @@ struct GeomMesh : GPrim {
 
 #endif
 
-  // Get Explicit Joint orders:  skel:joints or primvars:skel:joints
-  bool get_joints(std::vector<value::token> *joints) const;
+  // Get Explicit Joint orders: uniform token[] type.
+  //  `skel:joints` or `primvars:skel:joints`
+  std::vector<value::token> get_joints() const;
 
 #if 0 // Deprecated: Use tydra::GetGeomSubsets() instead.
   ///


### PR DESCRIPTION
Support explicit joint orders: https://github.com/lighttransport/tinyusdz/issues/218

Also fixes duplicated `Skeleton` is exported when the scene contains multiple skinned meshes.