### PR TITLE
Potential fix for code scanning alert no. 50: Redundant null check due to previous dereference

### DIFF
--- a/src/external/miniz.c
+++ b/src/external/miniz.c
@@ -2454,7 +2454,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
     size_t out_buf_size_mask = (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF) ? (size_t)-1 : ((pOut_buf_next - pOut_buf_start) + *pOut_buf_size) - 1, dist_from_out_buf_start;
 
     /* Ensure the output buffer's size is a power of 2, unless the output buffer is large enough to hold the entire output file (in which case it doesn't matter). */
-    if ((!pOut_buf_start) || (!pOut_buf_next) || (!pIn_buf_size) || (!pOut_buf_size))
+    if ((!pOut_buf_start) || (!pOut_buf_next) || (!pOut_buf_size))
     {
         return TINFL_STATUS_BAD_PARAM;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/lighttransport/tinyusdz/security/code-scanning/50](https://github.com/lighttransport/tinyusdz/security/code-scanning/50)

To fix the issue, the null check for `pIn_buf_size` on line 2457 should be removed because it is redundant. The dereference of `*pIn_buf_size` on line 2452 already assumes that `pIn_buf_size` is non-null. Removing the redundant check will simplify the code and eliminate the flagged issue without changing the program's functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
