### PR TITLE
Potential fix for code scanning alert no. 49: Multiplication result converted to larger type

### DIFF
--- a/src/external/stb_image.h
+++ b/src/external/stb_image.h
@@ -4792,7 +4792,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
          stbi_uc *in = cur;
          stbi_uc *out = dest;
          stbi_uc inb = 0;
-         stbi__uint32 nsmp = x*img_n;
+         stbi__uint32 nsmp = (size_t)x * img_n;
 
          // expand bits to bytes first
          if (depth == 4) {
@@ -4827,7 +4827,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
       } else if (depth == 16) {
          // convert the image data from big-endian to platform-native
          stbi__uint16 *dest16 = (stbi__uint16*)dest;
-         stbi__uint32 nsmp = x*img_n;
+         stbi__uint32 nsmp = (size_t)x * img_n;
 
          if (img_n == out_n) {
             for (i = 0; i < nsmp; ++i, ++dest16, cur += 2)

--- a/src/external/stb_image.h
+++ b/src/external/stb_image.h
@@ -4792,7 +4792,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
          stbi_uc *in = cur;
          stbi_uc *out = dest;
          stbi_uc inb = 0;
-         stbi__uint32 nsmp = (size_t)x * img_n;
+         size_t nsmp = (size_t)x * img_n;
 
          // expand bits to bytes first
          if (depth == 4) {

--- a/src/external/stb_image.h
+++ b/src/external/stb_image.h
@@ -4827,7 +4827,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
       } else if (depth == 16) {
          // convert the image data from big-endian to platform-native
          stbi__uint16 *dest16 = (stbi__uint16*)dest;
-         stbi__uint32 nsmp = (size_t)x * img_n;
+         size_t nsmp = (size_t)x * img_n;
 
          if (img_n == out_n) {
             for (i = 0; i < nsmp; ++i, ++dest16, cur += 2)


### PR DESCRIPTION
Potential fix for [https://github.com/lighttransport/tinyusdz/security/code-scanning/49](https://github.com/lighttransport/tinyusdz/security/code-scanning/49)

To fix the issue, we need to ensure that the multiplication `x * img_n` is performed using a larger type, such as `size_t`, to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The specific changes are:
1. Modify the calculation of `nsmp` on line 4795 to cast `x` or `img_n` to `size_t` before the multiplication.
2. Similarly, modify the calculation of `nsmp` on line 4830 to cast one of the operands to `size_t`.

These changes ensure that the multiplication is safe and the result is accurate, even for large values of `x` and `img_n`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
