### PR TITLE
Do not add /MP for clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,7 @@ endif()
 # Enable /MP flags(multi processor build) for Visual Studio
 # Based on VTK's Cmake
 # No need to set this if you use Ninja Generator
-if(MSVC)
+if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # default on.
   # disable MP or reduce cores if you have less memory
   set(TINYUSDZ_CXX_MP_FLAG ON CACHE BOOL "Build with /MP flag enabled")


### PR DESCRIPTION
Adding /MP flag when building with clang causes error:

`clang-cl: error: argument unused during compilation: '/MP' [-Werror,-Wunused-command-line-argument]`