### PR TITLE
Ignore primvar indices when interpolation mode is 'constant'

### DIFF
--- a/src/tydra/scene-access.cc
+++ b/src/tydra/scene-access.cc
@@ -2667,7 +2667,10 @@ bool GetGeomPrimvar(const Stage &stage, const GPrim *gprim,
   std::string index_name = primvar_name + kIndices;
   const auto indexIt = gprim->props.find(index_name);
 
-  if (indexIt != gprim->props.end()) {
+  // Primvar indices are only relevant for non-constant interpolation modes
+  bool constant_interpolation = primvar.get_interpolation() == tinyusdz::Interpolation::Constant;
+
+  if (indexIt != gprim->props.end() && !constant_interpolation) {
     if (indexIt->second.is_attribute()) {
       const Attribute &indexAttr = indexIt->second.get_attribute();
 


### PR DESCRIPTION
As discussed in https://github.com/lighttransport/tinyusdz/issues/241, the tydra renderscene converter currently fails when it encounters a primvar that has a corresponding indices attribute that is empty even if the interpolation mode is set to constant and the index is not used (as the _Indexed primvars API_ section of the [usdGeom primvars docs](https://openusd.org/release/api/class_usd_geom_primvar.html) implies). 

This MR adds an additional check when accessing a primvar that the interpolation mode is non-constant before it checks whether the indices attribute has values or not.