### PR TITLE
Fix uncommented code under #if 0 guard

### DIFF
--- a/src/c-tinyusd.h
+++ b/src/c-tinyusd.h
@@ -690,7 +690,7 @@ C_TINYUSD_EXPORT int c_tinyusd_attribute_meta_get(
 
 
 #if 0
-   Get i'th targetPaths
+/*   Get i'th targetPaths */
 C_TINYUSD_EXPORT int c_tinyusd_attribute_connection_get(CTinyUSDAttribute *attr, uint32_t n, const CTinyUSDPath *connectionPaths);
 #endif
 


### PR DESCRIPTION
Code within `#if 0` blocks is still tokenized and this line emits a warning under gcc, which fails with the default -Werror flags.


eg:
https://godbolt.org/z/6qdjxM6d9