### PR TITLE
Fix NRVO build errors with clang-21+

### DIFF
--- a/src/asset-resolution.cc
+++ b/src/asset-resolution.cc
@@ -105,22 +105,22 @@ bool AssetResolutionResolver::find(const std::string &assetPath) const {
 std::string AssetResolutionResolver::resolve(
     const std::string &assetPath) const {
 
+  std::string result;
   std::string ext = io::GetFileExtension(assetPath);
 
   if (_asset_resolution_handlers.count(ext)) {
     if (_asset_resolution_handlers.at(ext).resolve_fun) {
-      std::string resolvedPath;
       std::string err;
 
       // Use custom handler's userdata
       void *userdata = _asset_resolution_handlers.at(ext).userdata;
 
-      int ret = _asset_resolution_handlers.at(ext).resolve_fun(assetPath.c_str(), _search_paths, &resolvedPath, &err, userdata);
+      int ret = _asset_resolution_handlers.at(ext).resolve_fun(assetPath.c_str(), _search_paths, &result, &err, userdata);
       if (ret != 0) {
-        return std::string();
+        result.clear();
       }
 
-      return resolvedPath;
+      return result;
 
     } else {
       DCOUT("Resolve function is nullptr. Fallback to wildcard handler or built-in file handler.");
@@ -129,41 +129,40 @@ std::string AssetResolutionResolver::resolve(
 
   if (_asset_resolution_handlers.count("*")) {
     if (_asset_resolution_handlers.at("*").resolve_fun) {
-      std::string resolvedPath;
       std::string err;
 
       // Use custom handler's userdata
       void *userdata = _asset_resolution_handlers.at("*").userdata;
 
-      int ret = _asset_resolution_handlers.at("*").resolve_fun(assetPath.c_str(), _search_paths, &resolvedPath, &err, userdata);
+      int ret = _asset_resolution_handlers.at("*").resolve_fun(assetPath.c_str(), _search_paths, &result, &err, userdata);
       if (ret != 0) {
-        return std::string();
+        result.clear();
       }
 
-      return resolvedPath;
+      return result;
 
     }
 
-    return std::string();
+    return result;
   }
 
   DCOUT("cwd = " << _current_working_path);
   DCOUT("search_paths = " << _search_paths);
   DCOUT("assetPath = " << assetPath);
 
-  std::string rpath;
   if ((_current_working_path == ".") || (_current_working_path == "./")) {
-    rpath = io::FindFile(assetPath, {});
+    result = io::FindFile(assetPath, {});
   } else {
-    rpath = io::FindFile(assetPath, {_current_working_path});
+    result = io::FindFile(assetPath, {_current_working_path});
   }
 
-  if (rpath.size()) {
-    return rpath;
+  if (result.size()) {
+    return result;
   }
 
   // TODO: Cache resolition.
-  return io::FindFile(assetPath, _search_paths);
+  result = io::FindFile(assetPath, _search_paths);
+  return result;
 }
 
 bool AssetResolutionResolver::open_asset(const std::string &resolvedPath, const std::string &assetPath,

--- a/src/composition.cc
+++ b/src/composition.cc
@@ -1386,11 +1386,11 @@ static nonstd::optional<Prim> ReconstructPrimFromPrimSpec(
 static nonstd::optional<Prim> ReconstructPrimFromPrimSpecRec(
     const PrimSpec &primspec, std::string *warn, std::string *err) {
 
-  auto pprim = ReconstructPrimFromPrimSpec(primspec, warn, err);
+  nonstd::optional<Prim> pprim = ReconstructPrimFromPrimSpec(primspec, warn, err);
   if (!pprim) {
-    return nonstd::nullopt;
+    return pprim;
   }
-  
+
   for (size_t i = 0; i < primspec.children().size(); i++) {
     if (auto pv = ReconstructPrimFromPrimSpecRec(primspec.children()[i], warn, err)) {
       pprim.value().children().emplace_back(std::move(pv.value()));

--- a/src/io-util.cc
+++ b/src/io-util.cc
@@ -423,7 +423,7 @@ std::string ExpandFilePath(const std::string &_filepath, void *) {
   wordexp_t p;
 
   if (filepath.empty()) {
-    return "";
+    return s;
   }
 
   // Quote the string to keep any spaces in filepath intact.

--- a/src/prim-types.cc
+++ b/src/prim-types.cc
@@ -1970,17 +1970,16 @@ bool AttrMetas::has_colorSpace() const {
 }
 
 value::token AttrMetas::get_colorSpace() const {
-  if (!has_colorSpace()) {
-    return value::token();
-  }
-
-  const MetaVariable &mv = meta.at("colorSpace");
   value::token tok;
-  if (mv.get_value<value::token>(&tok)) {
+
+  if (!has_colorSpace()) {
     return tok;
   }
 
-  return value::token();
+  const MetaVariable &mv = meta.at("colorSpace");
+  mv.get_value<value::token>(&tok);
+
+  return tok;
 }
 
 bool AttrMetas::has_unauthoredValuesIndex() const {

--- a/src/str-util.cc
+++ b/src/str-util.cc
@@ -112,7 +112,8 @@ std::string unescapeControlSequence(const std::string &str) {
   std::string s;
 
   if (str.size() < 2) {
-    return str;
+    s = str;
+    return s;
   }
 
   for (size_t i = 0; i < str.size(); i++) {
@@ -544,7 +545,8 @@ std::vector<std::string> to_utf8_chars(const std::string &str) {
     std::string s = detail::extract_utf8_char(str, uint32_t(i), len);
     if (len == 0) {
       // invalid char
-      return std::vector<std::string>();
+      utf8_chars.clear();
+      return utf8_chars;
     }
 
     i += uint64_t(len);
@@ -641,7 +643,8 @@ std::vector<uint32_t> to_codepoints(const std::string &str) {
     uint32_t cp = detail::to_codepoint(str.c_str() + i, char_len);
 
     if ((cp > kMaxUTF8Codepoint) || (char_len == 0)) {
-      return std::vector<uint32_t>();
+      cps.clear();
+      return cps;
     }
 
     cps.push_back(cp);
@@ -683,7 +686,8 @@ std::string makeIdentifierValid(const std::string &str, bool is_utf8) {
 
   if (str.empty()) {
     // return '_'
-    return "_";
+    s = "_";
+    return s;
   }
 
   // first char

--- a/src/tydra/scene-access.cc
+++ b/src/tydra/scene-access.cc
@@ -2489,7 +2489,7 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
     if (err) {
       (*err) += "Prim must be GeomMesh.\n";
     }
-    return std::vector<std::pair<std::string, const tinyusdz::BlendShape *>>{};
+    return dst;
   }
 
   //
@@ -2504,8 +2504,8 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
       if (err) {
         (*err) += "Failed to get `skel:blendShapes` attribute.\n";
       }
-      return std::vector<
-          std::pair<std::string, const tinyusdz::BlendShape *>>{};
+      dst.clear();
+      return dst;
     }
 
     if (pmesh->blendShapeTargets.value().is_path()) {
@@ -2515,22 +2515,22 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
               "Array size mismatch with `skel:blendShapes` and "
               "`skel:blendShapeTargets`.\n";
         }
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
 
       const Path &targetPath = pmesh->blendShapeTargets.value().targetPath;
       const Prim *bsprim{nullptr};
       if (!stage.find_prim_at_path(targetPath, bsprim, err)) {
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
       if (!bsprim) {
         if (err) {
           (*err) += "Internal error. BlendShape Prim is nullptr.\n";
         }
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
 
       if (const auto *bs = bsprim->as<BlendShape>()) {
@@ -2540,8 +2540,8 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
           (*err) += fmt::format("{} is not BlendShape Prim.\n",
                                 targetPath.full_path_name());
         }
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
 
     } else if (pmesh->blendShapeTargets.value().is_pathvector()) {
@@ -2552,8 +2552,8 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
               "Array size mismatch with `skel:blendShapes` and "
               "`skel:blendShapeTargets`.\n";
         }
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
     } else {
       if (err) {
@@ -2561,8 +2561,8 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
             "Invalid or unsupported definition of `skel:blendShapeTargets` "
             "relationship.\n";
       }
-      return std::vector<
-          std::pair<std::string, const tinyusdz::BlendShape *>>{};
+      dst.clear();
+      return dst;
     }
 
     for (size_t i = 0;
@@ -2571,15 +2571,15 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
           pmesh->blendShapeTargets.value().targetPathVector[i];
       const Prim *bsprim{nullptr};
       if (!stage.find_prim_at_path(targetPath, bsprim, err)) {
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
       if (!bsprim) {
         if (err) {
           (*err) += "Internal error. BlendShape Prim is nullptr.";
         }
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
 
       if (const auto *bs = bsprim->as<BlendShape>()) {
@@ -2589,8 +2589,8 @@ GetBlendShapes(const tinyusdz::Stage &stage, const tinyusdz::Prim &prim,
           (*err) += fmt::format("{} is not BlendShape Prim.",
                                 targetPath.full_path_name());
         }
-        return std::vector<
-            std::pair<std::string, const tinyusdz::BlendShape *>>{};
+        dst.clear();
+        return dst;
       }
     }
   }

--- a/src/usdGeom.cc
+++ b/src/usdGeom.cc
@@ -886,6 +886,7 @@ const std::vector<int32_t> GeomMesh::get_faceVertexIndices(double time) const {
 
 std::vector<value::token> GeomMesh::get_joints() const {
   constexpr auto kSkelJoints = "skel:joints";
+  std::vector<value::token> dst;
 #if 0
   if (has_primvar(kSkelJoints)) {
     // 'primvars:skel:joints'
@@ -893,22 +894,21 @@ std::vector<value::token> GeomMesh::get_joints() const {
     GeomPrimvar primvar;
     if (!get_primvar(kSkelJoints, &primvar, &err)) {
       DCOUT("Invalid `skel:joints` primvar. err = " << err);
-      return {};
+      return dst;
     }
 
     if (primvar.has_indices()) {
-      // indexed primvar for skel:joint is not supported 
+      // indexed primvar for skel:joint is not supported
       DCOUT("Indexed primvar is not supported for `skel:joints`");
-      return {};
+      return dst;
     }
 
     const Attribute &attr = primvar.get_attribute();
     if (!attr.is_uniform()) {
       DCOUT("`skel:joints` must be uniform attribute");
-      return {};
+      return dst;
     }
 
-    std::vector<value::token> dst;
     if (!primvar.get_value(&dst)) {
       DCOUT("`skel:joints` must be token[] type, but got " << primvar.type_name());
     }
@@ -917,23 +917,22 @@ std::vector<value::token> GeomMesh::get_joints() const {
   {
     // lookup `skel:joints` prop
     if (!props.count(kSkelJoints)) {
-      return {};
+      return dst;
     }
 
     const auto &prop = props.at(kSkelJoints);
     if (prop.get_attribute().is_uniform() && prop.get_attribute().type_name() == "token[]") {
-      
-      std::vector<value::token> dst;
+
       if (!prop.get_attribute().get_value(&dst)) {
-        return {};
+        return dst;
       }
 
       return dst;
-      
-    } 
+
+    }
     DCOUT("`skel:joints` must be uniform token[] attribute, but got " << prop.value_type_name() << " (or Relationship))");
   }
-  return {};
+  return dst;
 }
 
 // static

--- a/src/usdShade.cc
+++ b/src/usdShade.cc
@@ -51,29 +51,30 @@ bool UsdShadePrim::has_sdr_metadata(const std::string &key) {
 }
 
 const std::string UsdShadePrim::get_sdr_metadata(const std::string &key) {
+  std::string svalue;
+
   if (!metas().sdrMetadata.has_value()) {
-    return std::string();
+    return svalue;
   }
 
   const Dictionary &dict = metas().sdrMetadata.value();
 
   if (!HasCustomDataKey(dict, key)) {
-    return std::string();
+    return svalue;
   }
 
   // check the type of value.
   MetaVariable var;
   if (!GetCustomDataByKey(dict, key, &var)) {
-    return std::string();
+    return svalue;
   }
 
   if (var.type_id() != value::TypeTraits<std::string>::type_id()) {
-    return std::string();
+    return svalue;
   }
 
-  std::string svalue;
   if (!var.get_value(&svalue)) {
-    return std::string();
+    svalue.clear();
   }
 
   return svalue;


### PR DESCRIPTION
## Summary
- Restructure functions across 8 source files to use a single named return variable per function, enabling Named Return Value Optimization (NRVO)
- Fixes `-Werror,-Wnrvo` build failures introduced by clang-21 without triggering `-Wpessimizing-move`
- Verified clean builds with g++ 13.3, clang++-20, and clang++-21

## Test plan
- [x] Build with g++ 13.3 — 0 errors, 0 warnings
- [x] Build with clang++-20 — 0 errors, 0 warnings
- [x] Build with clang++-21 (original failing compiler) — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)