### PR TITLE
Fixed build on Linux - missing definitions for 

### DIFF
--- a/src/value-types.hh
+++ b/src/value-types.hh
@@ -10,6 +10,7 @@
 ///
 #pragma once
 
+#include <cinttypes>
 #include <algorithm>
 #include <array>
 #include <cmath>


### PR DESCRIPTION
Fixed missing definitions for `uint8_t`, `uint16_t`, `uint32_t` and `uint64_t` in `value-types.hh` that failed to compile on Linux.